### PR TITLE
patched missing write function from original repo

### DIFF
--- a/src/ssd1306.h
+++ b/src/ssd1306.h
@@ -231,6 +231,15 @@ uint8_t     ssd1306_printFixed2x(uint8_t xpos, uint8_t y, const char ch[], EFont
 uint8_t     ssd1306_printFixedN(uint8_t xpos, uint8_t y, const char ch[], EFontStyle style, uint8_t factor);
 
 /**
+ * @brief Prints single character to display at current cursor position
+ *
+ * Prints single character to display at current cursor position
+ * @param ch - character to print to the display. 'LF' and 'CR' are skipped
+ * @return returns number of printed characters.
+ */
+size_t      ssd1306_write(uint8_t ch);
+
+/**
  * Prints text to screen using font 6x8.
  * @param x - horizontal position in pixels
  * @param y - vertical position in blocks (pixels/8)

--- a/src/ssd1306_generic.c
+++ b/src/ssd1306_generic.c
@@ -353,6 +353,49 @@ uint8_t ssd1306_printFixedN(uint8_t xpos, uint8_t y, const char ch[], EFontStyle
     return j;
 }
 
+size_t ssd1306_write(uint8_t ch)
+{
+    static lcduint_t xpos = 0;
+    static lcduint_t ypos = 0;
+    if (ch == '\r')
+    {
+        xpos = 0;
+        return 0;
+    }
+    else if ( (xpos > s_displayWidth - s_fixedFont.width) || (ch == '\n') )
+    {
+        xpos = 0;
+        ypos += s_fixedFont.height;
+        if ( ypos > s_displayHeight - s_fixedFont.height )
+        {
+            ypos = 0;
+        }
+        ssd1306_clearBlock(0, ypos>>3, s_displayWidth, s_fixedFont.height);
+        if (ch == '\n')
+        {
+            return 0;
+        }
+    }
+    ch -= s_fixedFont.ascii_offset;
+    ssd1306_drawBitmap( xpos,
+                        ypos>>3,
+                        s_fixedFont.width,
+                        s_fixedFont.height,
+                       &s_fixedFont.data[ ch * s_fixedFont.pages * s_fixedFont.width ] );
+    xpos += s_fixedFont.width;
+    return 1;
+}
+
+size_t ssd1306_print(const char ch[])
+{
+    size_t n = 0;
+    while (*ch)
+    {
+        n += ssd1306_write(*ch);
+        ch++;
+    }
+    return n;
+}
 
 uint8_t ssd1306_charF6x8(uint8_t x, uint8_t y, const char ch[], EFontStyle style)
 {


### PR DESCRIPTION
Your fork as it is did not compile and complained about a missing write function, I added it but as some naming have changed for width and height, I blindly copied from some similar to the file.
Now at least I compile and pop a hex out, but I'm still not confident enough to start with functionnal tests on the watch.